### PR TITLE
update README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,22 @@ Then, from your command line:
 
 ```bash
 # Clone this repository
-git clone https://github.com/nexB/scancode-workbench.git
+$ git clone https://github.com/nexB/scancode-workbench.git
 
 # Go into the repository
-cd scancode-workbench
+$ cd scancode-workbench
 
 # Install dependencies and run the app
-npm install
+$ npm install
 
 # Rebuild native Node.js modules against the app version of Node.js
 # MacOS, Linux and Git Bash on Windows
-$(npm bin)/electron-rebuild
+$ $(npm bin)/electron-rebuild
 # Windows except for Git Bash
-.\node_modules\.bin\electron-rebuild.cmd
+> .\node_modules\.bin\electron-rebuild.cmd
 
 # Run the app
-npm start
+$ npm start
 ```
 
 ## Release instructions

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ $(npm bin)/electron-rebuild
 $ npm start
 ```
 
-## Release instructions
+## Release Instructions
 
 You can build a `dist` directory containing executables for any one of three 
 target platforms by running:


### PR DESCRIPTION
```
# Clone this repository
git clone https://github.com/nexB/scancode-workbench.git

# Go into the repository
cd scancode-workbench

# Install dependencies and run the app
npm install

# Rebuild native Node.js modules against the app version of Node.js
# MacOS, Linux and Git Bash on Windows
$(npm bin)/electron-rebuild
# Windows except for Git Bash
.\node_modules\.bin\electron-rebuild.cmd

# Run the app
npm start
```

I am confused about the command `$(npm bin)/electron-rebuild` and thought that I have to use only `(npm bin)/electron-rebuild` in the terminal and get some error. So I think we should change these lines like -

```
# Clone this repository
$ git clone https://github.com/nexB/scancode-workbench.git

# Go into the repository
$ cd scancode-workbench

# Install dependencies and run the app
$  $(npm bin)/electron-rebuild
# Windows except for Git Bash
> .\node_modules\.bin\electron-rebuild.cmd

# Run the app
$ npm start
```
Another thing it provides consistency to the README.md file as below in the Release instructions (in README.md) command is written with` $ `sign.